### PR TITLE
Destroy GO rather than transform

### DIFF
--- a/Lib/Patch.cs
+++ b/Lib/Patch.cs
@@ -151,7 +151,7 @@ namespace Veauty.GameObject
                     for (var i = 0; i < removeLast.diff; i++)
                     {
                         var child = go.transform.GetChild(removeLast.length);
-                        UnityEngine.Object.Destroy(child);
+                        UnityEngine.Object.Destroy(child.gameObject);
                     }
                     return go;
                 }


### PR DESCRIPTION
This pull requests fixes an issue that arises when deleting a node. Unity throws this error.

```
Can't destroy Transform component of 'Item'. If you want to destroy the game object, please call 'Destroy' on the game object instead. Destroying the transform component is not allowed.
```